### PR TITLE
Don't try to #include from <sys/int_limits.h> on Mac OS X.

### DIFF
--- a/dtrace/dtrace_h.pxd
+++ b/dtrace/dtrace_h.pxd
@@ -8,10 +8,16 @@ cdef extern from "libelf_workaround.h":
     pass
 
 
-cdef extern from "sys/int_limits.h":
-    # needed for quantize mths.
-    cdef int64_t INT64_MAX
-    cdef int64_t INT64_MIN
+IF UNAME_SYSNAME == "Darwin":
+    cdef extern from "stdint.h":
+        # needed for quantize mths.
+        cdef int64_t INT64_MAX
+        cdef int64_t INT64_MIN
+ELSE:
+    cdef extern from "sys/int_limits.h":
+        # needed for quantize mths.
+        cdef int64_t INT64_MAX
+        cdef int64_t INT64_MIN
 
 
 cdef extern from "sys/dtrace.h":


### PR DESCRIPTION
It isn't there for me (on OS X 10.6.8)
