### PR TITLE
Fix ctypes DTraceConsumerThread to also call dtrace_close

### DIFF
--- a/dtrace_ctypes/consumer.py
+++ b/dtrace_ctypes/consumer.py
@@ -256,6 +256,12 @@ class DTraceConsumerThread(Thread):
         if LIBRARY.dtrace_setopt(self.handle, 'aggsize', '4m') != 0:
             raise Exception(get_error_msg(self.handle))
 
+    def __del__(self):
+        """
+        Always close the DTrace handle :-)
+        """
+        LIBRARY.dtrace_close(self.handle)
+
     def run(self):
         Thread.run(self)
         # set simple output callbacks


### PR DESCRIPTION
The ctypes DTraceConsumerThread does not currently call dtrace_close on its handle, so it gets leaked. This copies to destructor from DTraceConsumer.