### PR TITLE
Fix Cython DTrace handle leak

### DIFF
--- a/dtrace_cython/consumer.pyx
+++ b/dtrace_cython/consumer.pyx
@@ -257,11 +257,11 @@ cdef class DTraceConsumer:
             raise Exception(dtrace_errmsg(self.handle,
                                           dtrace_errno(self.handle)))
 
-    def __delalloc__(self):
+    def __dealloc__(self):
         """
         Release DTrace handle.
         """
-        if self.handle != NULL:
+        if hasattr(self, 'handle') and self.handle != NULL:
             dtrace_close(self.handle)
 
     cpdef compile(self, char * script):
@@ -376,11 +376,11 @@ cdef class DTraceContinuousConsumer:
             raise Exception(dtrace_errmsg(self.handle,
                                           dtrace_errno(self.handle)))
 
-    def __delalloc__(self):
+    def __dealloc__(self):
         """
         Release DTrace handle.
         """
-        if self.handle != NULL:
+        if hasattr(self, 'handle') and self.handle != NULL:
             dtrace_stop(self.handle)
             dtrace_close(self.handle)
 


### PR DESCRIPTION
This is caused by a typo: __delalloc__ should be __dealloc__:
https://github.com/tmetsch/python-dtrace/issues/8#issuecomment-352487596

Fixes https://github.com/tmetsch/python-dtrace/issues/8

CC: @jrtc27 