### PR TITLE
dtrace_ctypes_test.py: Add missing return 0 in callback

### DIFF
--- a/tests/dtrace_ctypes_test.py
+++ b/tests/dtrace_ctypes_test.py
@@ -32,3 +32,4 @@ class TestDTraceConsumer(unittest.TestCase):
     def _get_output(self, data, arg):
         tmp = c_char_p(data.contents.dtbda_buffered).value.strip()
         self.out = tmp
+        return 0


### PR DESCRIPTION
This avoids a ctypes warning since the expected return type is int and not
"None".