### PR TITLE
Add support for building on FreeBSD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,28 @@ Created on Oct 10, 2011
 
 from distutils.core import setup
 from distutils.extension import Extension
+import os
+import platform
 import sys
 try:
     from Cython.Build import build_ext, cythonize
-
+    extra_args = {}
+    if platform.system().lower().startswith("freebsd"):
+        # On FreeBSD the dtrace headers are not installed by default.
+        src_dir = os.getenv("FREEBSD_SRC_DIR", "/usr/src")
+        if not os.path.exists(os.path.join(src_dir, "sys/cddl")):
+            raise ImportError("Cannot find FreeBSD DTrace headers")
+        extra_args["include_dirs"] = [
+            os.path.join(src_dir, "sys/cddl/compat/opensolaris"),
+            os.path.join(src_dir, "sys/cddl/contrib/opensolaris/uts/common"),
+            os.path.join(src_dir, "cddl/contrib/opensolaris/lib/libdtrace/common"),
+        ]
     BUILD_EXTENSION = {'build_ext': build_ext}
-    EXT_MODULES = cythonize([Extension("dtrace", ["dtrace_cython/dtrace_h.pxd",
-                                                  "dtrace_cython/consumer.pyx"],
-                             libraries=["dtrace"])],
+    EXT_MODULES = cythonize([
+        Extension("dtrace", ["dtrace_cython/dtrace_h.pxd",
+                             "dtrace_cython/consumer.pyx"],
+                  libraries=["dtrace"],
+                  **extra_args)],
         language_level=sys.version_info.major)
 
 except ImportError:


### PR DESCRIPTION
On FreeBSD the DTrace headers are not installed by default so we need to
include them from the source directory.