### PR TITLE
Allow python-dtrace to work on macOS

### DIFF
--- a/dtrace_ctypes/consumer.py
+++ b/dtrace_ctypes/consumer.py
@@ -11,6 +11,7 @@ import threading
 import time
 from ctypes import (byref, c_char_p, c_int, c_uint, c_void_p, cast, cdll,
                     CDLL, CFUNCTYPE, POINTER)
+from ctypes.util import find_library
 from threading import Thread
 
 from dtrace_ctypes.dtrace_structs import (dtrace_aggdata, dtrace_bufdata,
@@ -20,11 +21,7 @@ from dtrace_ctypes.dtrace_structs import (dtrace_aggdata, dtrace_bufdata,
                                           DTRACE_WORKSTATUS_DONE,
                                           DTRACE_WORKSTATUS_ERROR)
 
-if platform.system().startswith("Darwin"):
-    _LIBNAME = "libdtrace.dylib"
-else:
-    _LIBNAME = "libdtrace.so"
-_LIBRARY = cdll.LoadLibrary(_LIBNAME)
+_LIBRARY = cdll.LoadLibrary(find_library("dtrace"))
 
 # =============================================================================
 # chewing and output walkers

--- a/dtrace_cython/dtrace_h.pxd
+++ b/dtrace_cython/dtrace_h.pxd
@@ -1,5 +1,6 @@
 
 from libc.stdint cimport uint16_t, int32_t, uint32_t, int64_t, uint64_t
+from libc.stdio cimport FILE
 
 
 cdef extern from "libelf_workaround.h":
@@ -118,7 +119,7 @@ cdef extern from "dtrace.h":
     int dtrace_go(dtrace_hdl_t *)
     int dtrace_stop(dtrace_hdl_t *)
     void dtrace_sleep(dtrace_hdl_t *)
-    dtrace_workstatus_t dtrace_work(dtrace_hdl_t * , char * , dtrace_consume_probe_f * , dtrace_consume_rec_f * , void *)
+    dtrace_workstatus_t dtrace_work(dtrace_hdl_t * , FILE * , dtrace_consume_probe_f * , dtrace_consume_rec_f * , void *)
 
     # walking aggregate
     int dtrace_aggregate_walk_valsorted(dtrace_hdl_t * , dtrace_aggregate_f * , void *)

--- a/tests/dtrace_ctypes_test.py
+++ b/tests/dtrace_ctypes_test.py
@@ -20,7 +20,7 @@ class TestDTraceConsumer(unittest.TestCase):
     """
 
     def setUp(self):
-        self.out = ''
+        self.out = b''
         self.consumer = consumer.DTraceConsumer(out_func=self._get_output)
 
     def test_run_for_success(self):
@@ -38,5 +38,5 @@ class TestDTraceConsumer(unittest.TestCase):
 
     def _get_output(self, data, _arg):
         tmp = c_char_p(data.contents.dtbda_buffered).value.strip()
-        self.out = tmp
+        self.out += tmp
         return 0


### PR DESCRIPTION
Buffered libdtrace output on macOS appears to be broken until at least 10.15:

The -B flag is disabled in dtrace.c (https://opensource.apple.com/source/dtrace/dtrace-338.40.5/cmd/dtrace/dtrace.c.auto.html)
and compiling the dtrace command line tool with that flag enabled results in the same crash
that I see with python-dtrace:
```
* thread 1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x7fb100000000)
  * frame 0: 0x00007fff6f83de52 libsystem_platform.dylib`_platform_strlen + 18
    frame 1: 0x00007fff6f6d9891 libsystem_c.dylib`__vfprintf + 5379
    frame 2: 0x00007fff6f6ffad3 libsystem_c.dylib`__v2printf + 475
    frame 3: 0x00007fff6f6e5ee7 libsystem_c.dylib`_vsnprintf + 417
    frame 4: 0x00007fff6f6e5f90 libsystem_c.dylib`vsnprintf + 68
    frame 5: 0x00007fff6d3650e3 libdtrace.dylib`dt_printf + 524
    frame 6: 0x00007fff6d33da7f libdtrace.dylib`dt_consume_cpu + 2536
    frame 7: 0x00007fff6d33c9e0 libdtrace.dylib`dtrace_consume + 1090
    frame 8: 0x00007fff6d366534 libdtrace.dylib`dtrace_work + 116
    frame 9: 0x000000010d6be9ff dtrace2`main(argc=4, argv=0x00007ffee2547250) at dtrace2.c:1834:17
    frame 10: 0x00007fff6f647cc9 libdyld.dylib`start + 1
```

Work around this by passing a FILE * obtained from open_memstream
and reading it after each call to dtrace_work().
This should generally result in the same output (the hello world test now
passes on macOS), but there could be some corner cases that are different.