### PR TITLE
Fix variable name conflict with Python3 Thread implementation

### DIFF
--- a/dtrace_cython/consumer.pyx
+++ b/dtrace_cython/consumer.pyx
@@ -461,7 +461,7 @@ class DTraceConsumerThread(Thread):
         Initilizes the Thread.
         """
         Thread.__init__(self)
-        self._stop = threading.Event()
+        self._should_stop = threading.Event()
         self.sleep_time = sleep
         self.consume = consume
         self.consumer = DTraceContinuousConsumer(script, chew_func,
@@ -498,10 +498,10 @@ class DTraceConsumerThread(Thread):
         """
         Stop DTrace.
         """
-        self._stop.set()
+        self._should_stop.set()
 
     def stopped(self):
         """
         Used to check the status.
         """
-        return self._stop.isSet()
+        return self._should_stop.isSet()


### PR DESCRIPTION
The Thread class in Python 3.9 (and possible also older versions) already
has a _stop member function. This function is called by thread .join(),
but we have a variable with the same name so it will raise a "not callable"
exception. Fix this by renaming the DTraceConsumerThread variable.