### PR TITLE
cython DTraceConsumerThread: Avoid error in __del__ if __init__ failed

### DIFF
--- a/dtrace_cython/consumer.pyx
+++ b/dtrace_cython/consumer.pyx
@@ -472,9 +472,12 @@ class DTraceConsumerThread(Thread):
         """
         Make sure DTrace stops.
         """
-        if not self.consume:
-            self.consumer.snapshot()
-        del self.consumer
+        # This is called even if __init__ raises, so we have to check whether
+        # consumer was initialized.
+        if hasattr(self, "consumer"):
+            if not self.consume:
+                self.consumer.snapshot()
+            del self.consumer
 
     def run(self):
         """


### PR DESCRIPTION
If __init__ raised an exception __del__ will still be called and raise
an AttributeError when trying to access self.consumer.