### PR TITLE
Add support for building with AddressSanitizer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ try:
             os.path.join(src_dir,
                          "cddl/contrib/opensolaris/lib/libdtrace/common"),
         ]
+    if os.getenv("ENABLE_ASAN", None) is not None:
+        extra_args["extra_compile_args"] = ["-fsanitize=address"]
+        extra_args["extra_link_args"] = ["-fsanitize=address"]
     BUILD_EXTENSION = {'build_ext': build_ext}
     EXT_MODULES = cythonize(
         [


### PR DESCRIPTION
I used this to debug crashes on macOS (which is caused by broken
buffered output handling in the macOS libdtrace version, see #15).

This can be useful to debug memory handling bugs, but only really
works well if you also compiled Python with AddressSanitizer.