### PR TITLE
Install no-op callbacks when explicitly passing None

### DIFF
--- a/dtrace_ctypes/consumer.py
+++ b/dtrace_ctypes/consumer.py
@@ -54,6 +54,10 @@ def simple_chew_func(data, _arg):
     return 0
 
 
+def noop_chew_func(_data, _arg):
+    return 0
+
+
 def simple_chewrec_func(_data, rec, _arg):
     """
     Callback for record chewing.
@@ -63,12 +67,19 @@ def simple_chewrec_func(_data, rec, _arg):
     return 0
 
 
+noop_chewrec_func = simple_chewrec_func
+
+
 def simple_buffered_out_writer(bufdata, _arg):
     """
     In case dtrace_work is given None as filename - this one is called.
     """
     tmp = c_char_p(bufdata.contents.dtbda_buffered).value.strip()
     print('out >', tmp)
+    return 0
+
+
+def noop_buffered_out_writer(bufdata, _arg):
     return 0
 
 
@@ -84,6 +95,10 @@ def simple_walk(data, _arg):
 
     print('{0:60s} :{1:10d}'.format(name.decode(), instance))
 
+    return 0
+
+
+def noop_walk(_data, _arg):
     return 0
 
 # =============================================================================
@@ -191,32 +206,32 @@ class DTraceConsumer:
     A Pyton based DTrace consumer.
     """
     def __init__(self,
-                 chew_func=None,
-                 chew_rec_func=None,
-                 walk_func=None,
-                 out_func=None):
+                 chew_func=simple_chew_func,
+                 chew_rec_func=simple_chewrec_func,
+                 walk_func=simple_walk,
+                 out_func=simple_buffered_out_writer):
         """
         Constructor. will get the DTrace handle
         """
         if chew_func is not None:
             self.chew = CHEW_FUNC(chew_func)
         else:
-            self.chew = CHEW_FUNC(simple_chew_func)
+            self.chew = CHEW_FUNC(noop_chew_func)
 
         if chew_rec_func is not None:
             self.chew_rec = CHEWREC_FUNC(chew_rec_func)
         else:
-            self.chew_rec = CHEWREC_FUNC(simple_chewrec_func)
+            self.chew_rec = CHEWREC_FUNC(noop_chewrec_func)
 
         if walk_func is not None:
             self.walk = WALK_FUNC(walk_func)
         else:
-            self.walk = WALK_FUNC(simple_walk)
+            self.walk = WALK_FUNC(noop_walk)
 
         if out_func is not None:
             self.buf_out = BUFFERED_FUNC(out_func)
         else:
-            self.buf_out = BUFFERED_FUNC(simple_buffered_out_writer)
+            self.buf_out = BUFFERED_FUNC(noop_buffered_out_writer)
 
         # get dtrace handle
         self.handle = _dtrace_open()
@@ -293,10 +308,10 @@ class DTraceConsumerThread(Thread):
 
     def __init__(self,
                  script,
-                 chew_func=None,
-                 chew_rec_func=None,
-                 walk_func=None,
-                 out_func=None):
+                 chew_func=simple_chew_func,
+                 chew_rec_func=simple_chewrec_func,
+                 walk_func=simple_walk,
+                 out_func=simple_buffered_out_writer):
         """
         Constructor. will get the DTrace handle
         """
@@ -307,22 +322,22 @@ class DTraceConsumerThread(Thread):
         if chew_func is not None:
             self.chew = CHEW_FUNC(chew_func)
         else:
-            self.chew = CHEW_FUNC(simple_chew_func)
+            self.chew = CHEW_FUNC(noop_chew_func)
 
         if chew_rec_func is not None:
             self.chew_rec = CHEWREC_FUNC(chew_rec_func)
         else:
-            self.chew_rec = CHEWREC_FUNC(simple_chewrec_func)
+            self.chew_rec = CHEWREC_FUNC(noop_chewrec_func)
 
         if walk_func is not None:
             self.walk = WALK_FUNC(walk_func)
         else:
-            self.walk = WALK_FUNC(simple_walk)
+            self.walk = WALK_FUNC(noop_walk)
 
         if out_func is not None:
             self.buf_out = BUFFERED_FUNC(out_func)
         else:
-            self.buf_out = BUFFERED_FUNC(simple_buffered_out_writer)
+            self.buf_out = BUFFERED_FUNC(noop_buffered_out_writer)
 
         # get dtrace handle
         self.handle = _dtrace_open()

--- a/dtrace_cython/consumer.pyx
+++ b/dtrace_cython/consumer.pyx
@@ -186,6 +186,10 @@ def simple_chew(cpu):
     print('Running on CPU:', cpu)
 
 
+def noop_chew(_cpu):
+    pass
+
+
 def simple_chewrec(action):
     """
     Simple chewrec callback.
@@ -195,6 +199,10 @@ def simple_chewrec(action):
     print('Called action was:', action)
 
 
+def noop_chewrec(_action):
+    pass
+
+
 def simple_out(value):
     """
     A buffered output handler for all those prints.
@@ -202,6 +210,10 @@ def simple_out(value):
     value -- Line by line string of the DTrace output.
     """
     print('Value is:', value)
+
+
+def noop_out(_value):
+    pass
 
 
 def simple_walk(action, identifier, keys, value):
@@ -215,6 +227,10 @@ def simple_walk(action, identifier, keys, value):
     value -- the value.
     """
     print(action, identifier, keys, value)
+
+
+def noop_walk(_action, _identifier, _keys, _value):
+    pass
 
 # ----------------------------------------------------------------------------
 # The consumers
@@ -232,15 +248,16 @@ cdef class DTraceConsumer:
     cdef object chew_func
     cdef object chewrec_func
 
-    def __init__(self, chew_func=None, chewrec_func=None, out_func=None,
-                 walk_func=None):
+    def __init__(self, chew_func=simple_chew, chewrec_func=simple_chewrec,
+                 out_func=simple_out, walk_func=simple_walk):
         """
         Constructor. Gets a DTrace handle and sets some options.
+        Passing None as one of the callback arguments installs a no-op callback.
         """
-        self.chew_func = chew_func or simple_chew
-        self.chewrec_func = chewrec_func or simple_chewrec
-        self.out_func = out_func or simple_out
-        self.walk_func = walk_func or simple_walk
+        self.chew_func = noop_chew if chew_func is None else chew_func
+        self.chewrec_func = noop_chewrec if chewrec_func is None else simple_chewrec
+        self.out_func = noop_out if out_func is None else out_func
+        self.walk_func = noop_walk if walk_func is None else walk_func
 
         cdef int err
         if not hasattr(self, 'handle'):
@@ -355,15 +372,15 @@ cdef class DTraceContinuousConsumer:
     cdef object chewrec_func
     cdef object script
 
-    def __init__(self, str script, chew_func=None, chewrec_func=None,
-                 out_func=None, walk_func=None):
+    def __init__(self, str script, chew_func=simple_chew, chewrec_func=simple_chewrec,
+                 out_func=simple_out, walk_func=simple_walk):
         """
         Constructor. will get the DTrace handle
         """
-        self.chew_func = chew_func or simple_chew
-        self.chewrec_func = chewrec_func or simple_chewrec
-        self.out_func = out_func or simple_out
-        self.walk_func = walk_func or simple_walk
+        self.chew_func = noop_chew if chew_func is None else chew_func
+        self.chewrec_func = noop_chewrec if chewrec_func is None else simple_chewrec
+        self.out_func = noop_out if out_func is None else out_func
+        self.walk_func = noop_walk if walk_func is None else walk_func
         self.script = script.encode("utf-8")
 
         cdef int err
@@ -455,8 +472,9 @@ class DTraceConsumerThread(Thread):
     Helper Thread which can be used to continuously aggregate.
     """
 
-    def __init__(self, script, consume=True, chew_func=None, chewrec_func=None,
-                 out_func=None, walk_func=None, sleep=0):
+    def __init__(self, script, consume=True, chew_func=simple_chew,
+                 chewrec_func=simple_chewrec, out_func=simple_out,
+                 walk_func=simple_walk, sleep=0):
         """
         Initilizes the Thread.
         """


### PR DESCRIPTION
This commit retains the previous behaviour of installing simple_* callbacks
if no explicit override is passed, and allows passing None to install
no-op callbacks. I generally don't want the CPU: N prints so end up
having to use the API as follows:

```python
def simple_walk(action, identifier, keys, value):
    """
    action -- type of action (sum, avg, ...)
    identifier -- the id.
    keys -- list of keys.
    value -- the value.
    """
    values[keys[0]] += value

dtrace_thread = DTraceConsumerThread(syscall_script,
                                     walk_func=simple_walk,
                                     out_func=lambda v: None,
                                     chew_func=lambda v: None,
                                     chewrec_func=lambda v: None,
                                     sleep=1)
```
Allowing None instead of `lambda v: None` would make this a bit simpler.