### PR TITLE
Stop requiring the FreeBSD source code for FreeBSD13+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,18 +17,20 @@ try:
     from Cython.Build import build_ext, cythonize
     extra_args = {}
     if platform.system().lower().startswith("freebsd"):
-        # On FreeBSD the dtrace headers are not installed by default.
-        src_dir = os.getenv("FREEBSD_SRC_DIR", "/usr/src")
-        if not os.path.exists(os.path.join(src_dir, "sys/cddl")):
-            raise ImportError("Cannot find FreeBSD DTrace headers")
-        extra_args["include_dirs"] = [
-            os.path.join(src_dir,
-                         "sys/cddl/compat/opensolaris"),
-            os.path.join(src_dir,
-                         "sys/cddl/contrib/opensolaris/uts/common"),
-            os.path.join(src_dir,
-                         "cddl/contrib/opensolaris/lib/libdtrace/common"),
-        ]
+        # On older FreeBSD versions the dtrace headers are not
+        # installed by default, so we need to find the full sources.
+        if not os.path.exists("/usr/include/dtrace.h"):
+            src_dir = os.getenv("FREEBSD_SRC_DIR", "/usr/src")
+            if not os.path.exists(os.path.join(src_dir, "sys/cddl")):
+                raise ImportError("Cannot find FreeBSD DTrace headers")
+            extra_args["include_dirs"] = [
+                os.path.join(src_dir,
+                             "sys/cddl/compat/opensolaris"),
+                os.path.join(src_dir,
+                             "sys/cddl/contrib/opensolaris/uts/common"),
+                os.path.join(src_dir,
+                             "cddl/contrib/opensolaris/lib/libdtrace/common"),
+            ]
     if os.getenv("ENABLE_ASAN", None) is not None:
         extra_args["extra_compile_args"] = ["-fsanitize=address"]
         extra_args["extra_link_args"] = ["-fsanitize=address"]


### PR DESCRIPTION
Since https://github.com/freebsd/freebsd-src/commit/1f6612b444e3fc54697a4ef3167efdddff6944ea
the dtrace.h header is installed to /usr/include so we no longer
need to have the full source code installed just to find the headers
that we need to build the cython extension.